### PR TITLE
Updating gemspec redcarpet version to 3.4.0 and pedantic style changes

### DIFF
--- a/redcarpet-confluence.gemspec
+++ b/redcarpet-confluence.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = 'redcarpet-confluence'
-  gem.version       = '1.1.0'
+  gem.version       = '1.2.0'
   gem.authors       = ['Adam Stegman']
   gem.email         = ['me@adamstegman.com']
   gem.summary       = 'A Redcarpet renderer to convert Markdown to Confluence syntax.'

--- a/redcarpet-confluence.gemspec
+++ b/redcarpet-confluence.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = 'redcarpet-confluence'
-  gem.version       = '1.2.0'
+  gem.version       = '1.1.0'
   gem.authors       = ['Adam Stegman']
   gem.email         = ['me@adamstegman.com']
   gem.summary       = 'A Redcarpet renderer to convert Markdown to Confluence syntax.'
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
                       ]
   gem.require_paths = ['lib']
 
-  gem.add_dependency             'redcarpet', '~> 3.4.0'
+  gem.add_dependency             'redcarpet', '~> 3.4'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
 end

--- a/redcarpet-confluence.gemspec
+++ b/redcarpet-confluence.gemspec
@@ -4,16 +4,24 @@ Gem::Specification.new do |gem|
   gem.authors       = ['Adam Stegman']
   gem.email         = ['me@adamstegman.com']
   gem.summary       = 'A Redcarpet renderer to convert Markdown to Confluence syntax.'
-  gem.description   = "#{gem.summary}"
+  gem.description   = gem.summary.to_s
   gem.homepage      = 'https://github.com/adamstegman/redcarpet-confluence'
-  gem.license       = "MIT"
+  gem.license       = 'MIT'
 
   gem.executable    = 'md2conf'
-  gem.files         = Dir['lib/**/*.rb', 'Gemfile', 'README.md', 'Rakefile', 'redcarpet-confluence.gemspec']
-  gem.test_files    = Dir['spec/**/*.rb']
+  gem.files         = Dir[
+                        'lib/**/*.rb',
+                        'Gemfile',
+                        'README.md',
+                        'Rakefile',
+                        'redcarpet-confluence.gemspec'
+                      ]
+  gem.test_files    = Dir[
+                        'spec/**/*.rb'
+                      ]
   gem.require_paths = ['lib']
 
-  gem.add_dependency             'redcarpet', '~> 2.0'
+  gem.add_dependency             'redcarpet', '~> 3.4.0'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
Hi Adam,

This is my first commit to a random open source project on github, I'm very excited and probably committing many faux pas.  Sorry!

I want to use your gem, but I get errors in my audit tool saying the 2.0 version of redcarpet has security vulns in it.  Can we possibly update it?

Thanks,
Tom